### PR TITLE
onPointer events triggering on clicks outside of the signature canvas

### DIFF
--- a/core/src/Signature.tsx
+++ b/core/src/Signature.tsx
@@ -48,6 +48,7 @@ export const Signature = forwardRef<SignatureRef, Omit<SignatureProps, 'defaultP
     });
 
     const handlePointerUp = useEvent(() => {
+      if (!pointsRef.current) return;
       let result = pointsRef.current || [];
       onPointer && props.onPointer!(result);
       // Remove the temporary path element from DOM


### PR DESCRIPTION
Previously, clicking anywhere on the page would trigger the onPointer event, even if the user did not interact with the signature canvas.

This PR fixes the issue by checking the existence of pointsRef before triggering the callback. As a result, onPointer is now called only when the interaction originates from the canvas, preventing unrelated mousedown/mouseup events from triggering it.